### PR TITLE
食品選択機能追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :development do
   gem 'rails_best_practices'
   gem 'better_errors', '~> 2.9', '>= 2.9.1'
   gem 'binding_of_caller'
+  gem 'faker'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
       activesupport (>= 3.0.0)
     erubi (1.10.0)
     erubis (2.7.0)
+    faker (2.19.0)
+      i18n (>= 1.6, < 2)
     ffi (1.15.4)
     globalid (0.5.2)
       activesupport (>= 5.0)
@@ -246,6 +248,7 @@ DEPENDENCIES
   byebug
   carrierwave
   enum_help
+  faker
   jbuilder (~> 2.7)
   listen (~> 3.2)
   mysql2 (>= 0.4.4)

--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -7,7 +7,7 @@ class MealsController < ApplicationController
     begin
         @meal = current_user.meals.build(meal_params)
       if @meal.save
-        redirect_to root_path, success: t('.success')
+        redirect_to edit_meal_path(@meal), success: t('.success')
       else
         flash.now[:danger] = t('.failure')
         render :new
@@ -15,6 +15,14 @@ class MealsController < ApplicationController
     rescue ActionController::ParameterMissing
       redirect_to new_meal_path, danger: t('.need_image')
     end
+  end
+
+  def edit
+    @meal = current_user.meals.find(params[:id])
+  end
+
+  def update
+    
   end
 
   private

--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -23,7 +23,11 @@ class MealsController < ApplicationController
   end
 
   def update
-    
+    @meal = current_user.meals.find(params[:id])
+    food_ids = params[:meal][:food_ids]
+    food_ids.each do |food_id|
+      @meal.used_foods.create(food: Food.find_by(id: food_id))
+    end
   end
 
   private

--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -19,6 +19,7 @@ class MealsController < ApplicationController
 
   def edit
     @meal = current_user.meals.find(params[:id])
+    @foods = Food.all
   end
 
   def update

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -1,0 +1,9 @@
+class Food < ApplicationRecord
+  belongs_to :genre
+
+  enum role: { concrete: 0, abstract: 1 }
+
+  validates :name, presence: true, uniqueness: true
+  validates :calorie, presence: true
+  validates :role, presence: true
+end

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -1,5 +1,7 @@
 class Food < ApplicationRecord
   belongs_to :genre
+  has_many :used_foods, dependent: :destroy
+  has_many :meals, through: :used_foods
 
   enum role: { concrete: 0, abstract: 1 }
 

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,0 +1,3 @@
+class Genre < ApplicationRecord
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,3 +1,5 @@
 class Genre < ApplicationRecord
+  has_many :foods, dependent: :destroy
+  
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/meal.rb
+++ b/app/models/meal.rb
@@ -1,5 +1,7 @@
 class Meal < ApplicationRecord
   belongs_to :user
+  has_many :used_foods, dependent: :destroy
+  has_many :foods, through: :used_foods
 
   mount_uploader :meal_image, MealImageUploader
 

--- a/app/models/used_food.rb
+++ b/app/models/used_food.rb
@@ -1,0 +1,6 @@
+class UsedFood < ApplicationRecord
+  belongs_to :meal
+  belongs_to :food
+
+  validates :food_id, uniqueness: { scope: :meal_id }
+end

--- a/app/views/meals/edit.html.erb
+++ b/app/views/meals/edit.html.erb
@@ -1,4 +1,4 @@
 <div class="container">
   <h1 class="mt-3">食品選択</h1>
-    <%= p @meal %>
+  <%= image_tag @meal.meal_image.url, class: 'img-fluid d-block mx-auto', size: '500x500' %>
 </div>

--- a/app/views/meals/edit.html.erb
+++ b/app/views/meals/edit.html.erb
@@ -1,4 +1,8 @@
 <div class="container">
   <h1 class="mt-3">食品選択</h1>
   <%= image_tag @meal.meal_image.url, class: 'img-fluid d-block mx-auto', size: '500x500' %>
+  <%= form_with model: @meal, local: true do |f| %>
+    <%= f.collection_check_boxes :food_ids, @foods, :id, :name, class: 'form-control' %>
+    <%= f.submit nil %>
+  <% end %>
 </div>

--- a/app/views/meals/edit.html.erb
+++ b/app/views/meals/edit.html.erb
@@ -1,0 +1,4 @@
+<div class="container">
+  <h1 class="mt-3">食品選択</h1>
+    <%= p @meal %>
+</div>

--- a/app/views/meals/edit.html.erb
+++ b/app/views/meals/edit.html.erb
@@ -21,7 +21,8 @@
       </tbody>
     </table>
     <div class="row justify-content-end mt-5">
-      <%= f.submit '選択する', class: 'btn btn-primary col-sm-5' %>
+      <%= f.submit '選択する', class: 'btn btn-primary col-sm-2' %>
+      <%= link_to 'このなかにない', '#', class: 'btn btn-danger col-sm-2' %>
     </div>
   <% end %>
 </div>

--- a/app/views/meals/edit.html.erb
+++ b/app/views/meals/edit.html.erb
@@ -1,8 +1,27 @@
 <div class="container">
   <h1 class="mt-3">食品選択</h1>
   <%= image_tag @meal.meal_image.url, class: 'img-fluid d-block mx-auto', size: '500x500' %>
-  <%= form_with model: @meal, local: true do |f| %>
-    <%= f.collection_check_boxes :food_ids, @foods, :id, :name, class: 'form-control' %>
-    <%= f.submit nil %>
+  <%= form_with model: @meal, local: true, class: 'mt-3' do |f| %>
+    <table class="table table-hover table-bordered">
+      <thead>
+        <tr>
+          <th><%= Food.human_attribute_name(:name) %></th>
+          <th>選択する/しない</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= f.collection_check_boxes :food_ids, @foods, :id, :name do |food| %>
+          <%= food.label do %>
+            <tr>
+              <td><%= food.object.name %></td>
+              <td><%= food.check_box %></td>
+            </tr>
+          <% end %>
+        <% end %>
+      </tbody>
+    </table>
+    <div class="row justify-content-end mt-5">
+      <%= f.submit '選択する', class: 'btn btn-primary col-sm-5' %>
+    </div>
   <% end %>
 </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -3,6 +3,8 @@ ja:
     model:
       user: 'ユーザー'
       meal: '食事'
+      genre: 'ジャンル'
+      food: '食品'
     attributes:
       user:
         name: '名前'
@@ -11,6 +13,12 @@ ja:
         physical_activity_level: '身体活動レベル'
       meal:
         meal_image: '食事写真'
+      genre:
+        name: 'ジャンル名'
+      food:
+        name: '食品名'
+        calorie: 'カロリー'
+        role: '役割'
   enums:
     user:
       gender:
@@ -20,3 +28,7 @@ ja:
         low: '低い'
         normal: '普通'
         high: '高い'
+    food:
+      role:
+        concrete: '具体的'
+        abstract: '抽象的'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
   root 'top#index'
 
   resources :users, only: %i[new create]
-  resources :meals, only: %i[new create]
+  resources :meals, only: %i[new create edit update]
 end

--- a/db/migrate/20211118014103_create_genres.rb
+++ b/db/migrate/20211118014103_create_genres.rb
@@ -1,0 +1,9 @@
+class CreateGenres < ActiveRecord::Migration[6.0]
+  def change
+    create_table :genres do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211118014554_add_index_to_genres.rb
+++ b/db/migrate/20211118014554_add_index_to_genres.rb
@@ -1,0 +1,5 @@
+class AddIndexToGenres < ActiveRecord::Migration[6.0]
+  def change
+    add_index :genres, :name, unique: true
+  end
+end

--- a/db/migrate/20211118015148_create_foods.rb
+++ b/db/migrate/20211118015148_create_foods.rb
@@ -1,0 +1,12 @@
+class CreateFoods < ActiveRecord::Migration[6.0]
+  def change
+    create_table :foods do |t|
+      t.string :name, null: false
+      t.integer :calorie, null: false
+      t.integer :role, null: false
+      t.references :genre, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211118015305_add_index_to_food.rb
+++ b/db/migrate/20211118015305_add_index_to_food.rb
@@ -1,0 +1,5 @@
+class AddIndexToFood < ActiveRecord::Migration[6.0]
+  def change
+    add_index :foods, :name, unique: true
+  end
+end

--- a/db/migrate/20211118023303_create_used_foods.rb
+++ b/db/migrate/20211118023303_create_used_foods.rb
@@ -1,0 +1,10 @@
+class CreateUsedFoods < ActiveRecord::Migration[6.0]
+  def change
+    create_table :used_foods do |t|
+      t.references :meal, null: false, foreign_key: true
+      t.references :food, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211118023924_add_index_to_user_food.rb
+++ b/db/migrate/20211118023924_add_index_to_user_food.rb
@@ -1,0 +1,5 @@
+class AddIndexToUserFood < ActiveRecord::Migration[6.0]
+  def change
+    add_index :used_foods, [:meal_id, :food_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_18_015305) do
+ActiveRecord::Schema.define(version: 2021_11_18_023924) do
 
   create_table "foods", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -40,6 +40,16 @@ ActiveRecord::Schema.define(version: 2021_11_18_015305) do
     t.index ["user_id"], name: "index_meals_on_user_id"
   end
 
+  create_table "used_foods", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "meal_id", null: false
+    t.bigint "food_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["food_id"], name: "index_used_foods_on_food_id"
+    t.index ["meal_id", "food_id"], name: "index_used_foods_on_meal_id_and_food_id", unique: true
+    t.index ["meal_id"], name: "index_used_foods_on_meal_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "gender", null: false
@@ -51,4 +61,6 @@ ActiveRecord::Schema.define(version: 2021_11_18_015305) do
 
   add_foreign_key "foods", "genres"
   add_foreign_key "meals", "users"
+  add_foreign_key "used_foods", "foods"
+  add_foreign_key "used_foods", "meals"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_16_141637) do
+ActiveRecord::Schema.define(version: 2021_11_18_015305) do
+
+  create_table "foods", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "calorie", null: false
+    t.integer "role", null: false
+    t.bigint "genre_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["genre_id"], name: "index_foods_on_genre_id"
+    t.index ["name"], name: "index_foods_on_name", unique: true
+  end
+
+  create_table "genres", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_genres_on_name", unique: true
+  end
 
   create_table "meals", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "meal_image", null: false
@@ -31,5 +49,6 @@ ActiveRecord::Schema.define(version: 2021_11_16_141637) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "foods", "genres"
   add_foreign_key "meals", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,21 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+Genre.create!(name: 'ジャンル１')
+Genre.create!(name: 'ジャンル２')
+
+30.times do
+  Food.create!(
+    name: Faker::Food.unique.dish,
+    calorie: Faker::Number.number(digits: 3),
+    role: :concrete,
+    genre: Genre.first
+  )
+  Food.create!(
+    name: Faker::Food.unique.ingredient,
+    calorie: Faker::Number.number(digits: 3),
+    role: :concrete,
+    genre: Genre.last
+  )
+end


### PR DESCRIPTION
## 概要
食事で使われている食品を選択できる機能を追加

GoogleのAPIをつかった画像解析はおこなわず、まずはFakerでつくったダミーの食品データから選ぶ機能になっている。

Food、Genreモデルをつくり、さらにMealモデルとFoodモデルを紐付ける中間テーブル、UsedFoodモデルを作成し、
食品選択機能　＝　UsedFoodモデルのインスタンスを作成

という形で実装した

