### PR TITLE
食品選択のチェックボックス表示を切り替える

### DIFF
--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -33,10 +33,13 @@ class MealsController < ApplicationController
 
   def edit
     @meal = current_user.meals.find(params[:id])
-    foods_from_foods = Food.search_foods(@meal.pass_to_sql)
+
+    foods_from_foods = Food.concrete.search_foods(@meal.pass_to_sql)
     foods_from_genres = Genre.search_genres(@meal.pass_to_sql).map { |genre| genre.foods }
     searched_foods = foods_from_foods + foods_from_genres + Food.others
-    @foods = searched_foods.flatten.uniq
+    @concrete_foods = searched_foods.flatten.uniq
+
+    @abstract_foods = Food.abstract + Food.others
   end
 
   def update

--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -50,7 +50,7 @@ class MealsController < ApplicationController
       food_ids.each do |food_id|
         @meal.used_foods.find_or_create_by!(food: Food.find(food_id))
       end
-      @meal.update!(balance_of_payments: @meal.balance_of_payments_value)
+      @meal.update!(balance_of_payments: @meal.balance_of_payments_value, title: @meal.result_meal_title)
       redirect_to meal_path(@meal), success: t('.success')
     else
       redirect_to edit_meal_path(@meal), danger: t('.need_select')

--- a/app/javascript/checkbox.js
+++ b/app/javascript/checkbox.js
@@ -2,10 +2,16 @@ $(function(){
   $(".js-checkbox-others, #js-abstract-checkbox").hide();
   
   function changeDisplay() {
-    if ($(".chk:checked").length > 0) {
-      $(".js-checkbox-others").show();
+    if ($(".js-concrete-chk:checked").length > 0) {
+      $("#js-concrete-checkbox .js-checkbox-others").show();
     } else {
-      $(".js-checkbox-others").hide();
+      $("#js-concrete-checkbox .js-checkbox-others").hide();
+    };
+
+    if ($(".js-abstract-chk:checked").length > 0) {
+      $("#js-abstract-checkbox .js-checkbox-others").show();
+    } else {
+      $("#js-abstract-checkbox .js-checkbox-others").hide();
     };
   };
 

--- a/app/javascript/checkbox.js
+++ b/app/javascript/checkbox.js
@@ -2,13 +2,13 @@ $(function(){
   $(".js-checkbox-others, #js-abstract-checkbox").hide();
   
   function changeDisplay() {
-    if ($(".js-concrete-chk:checked").length > 0) {
+    if ($("#js-concrete-checkbox .js-chk:checked").length > 0) {
       $("#js-concrete-checkbox .js-checkbox-others").show();
     } else {
       $("#js-concrete-checkbox .js-checkbox-others").hide();
     };
 
-    if ($(".js-abstract-chk:checked").length > 0) {
+    if ($("#js-abstract-checkbox .js-chk:checked").length > 0) {
       $("#js-abstract-checkbox .js-checkbox-others").show();
     } else {
       $("#js-abstract-checkbox .js-checkbox-others").hide();

--- a/app/javascript/checkbox.js
+++ b/app/javascript/checkbox.js
@@ -1,5 +1,5 @@
 $(function(){
-  $(".js-checkbox-others").hide();
+  $(".js-checkbox-others, #js-abstract-checkbox").hide();
   
   function changeDisplay() {
     if ($(".chk:checked").length > 0) {
@@ -12,4 +12,9 @@ $(function(){
   changeDisplay();
 
   $("input[type='checkbox']").on('change', changeDisplay);
+
+  $("#js-abstract-button").on('click', function(){
+    $("#js-abstract-checkbox").show(),
+    $("#js-concrete-checkbox, #js-abstract-button").hide();
+  });
 });

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,9 +11,9 @@ class User < ApplicationRecord
 
   def required_calorie
     if male?
-      (7.16 - 0.0138 * age - 0.4235) * 238 * physical_activity_level_value / 3
+      ((7.16 - 0.0138 * age - 0.4235) * 238 * physical_activity_level_value / 3) * 0.9
     else
-      (6.19 - 0.0138 * age - 0.9708) * 238 * physical_activity_level_value / 3
+      ((6.19 - 0.0138 * age - 0.9708) * 238 * physical_activity_level_value / 3) * 0.9
     end
   end
 

--- a/app/views/meals/_meal.html.erb
+++ b/app/views/meals/_meal.html.erb
@@ -3,7 +3,7 @@
       <%= image_tag meal.meal_image.url, class: 'card-img-top', size: '200x300' %>
       <div class="card-body">
         <%= link_to meal_path(meal), class: 'card-title' do %>
-          <h5 class="card-title <%= meal.result_color %>"><%= meal.result_meal_title %></h5>
+          <h5 class="card-title <%= meal.result_color %>"><%= meal.title %></h5>
         <% end %>
         <p class="card-text"><%= meal.user.name %>さんの食事</p>
         <p class="card-text <%= meal.result_color %>"><%= meal.balance_of_payments_with_sign %></p>

--- a/app/views/meals/edit.html.erb
+++ b/app/views/meals/edit.html.erb
@@ -23,7 +23,32 @@
     </table>
     <div class="row justify-content-end mt-5">
       <%= f.submit '選択する', class: 'btn btn-primary col-sm-2' %>
-      <%= link_to 'このなかにない', '#', class: 'btn btn-danger col-sm-2' %>
     </div>
   <% end %>
+  <%= form_with model: @meal, local: true, class: 'mt-3' do |f| %>
+    <table class="table table-hover table-bordered">
+      <thead>
+        <tr>
+          <th><%= Food.human_attribute_name(:name) %></th>
+          <th>選択する/しない</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= f.collection_check_boxes :food_ids, @foods, :id, :name do |food| %>
+          <%= food.label do %>
+            <tr class="js-checkbox-<%= food.object.role %>">
+              <td><%= food.object.name %></td>
+              <td><%= food.check_box class: 'chk' %></td>
+            </tr>
+          <% end %>
+        <% end %>
+      </tbody>
+    </table>
+    <div class="row justify-content-end mt-5">
+      <%= f.submit '選択する', class: 'btn btn-primary col-sm-2' %>
+    </div>
+  <% end %>
+  <div class="row justify-content-end mt-2">
+    <button class="btn btn-danger col-sm-2">このなかにない</button>
+  </div>
 </div>

--- a/app/views/meals/edit.html.erb
+++ b/app/views/meals/edit.html.erb
@@ -16,7 +16,7 @@
             <%= food.label do %>
               <tr class="js-checkbox-<%= food.object.role %>">
                 <td><%= food.object.name %></td>
-                <td><%= food.check_box class: 'js-concrete-chk' %></td>
+                <td><%= food.check_box class: 'js-chk' %></td>
               </tr>
             <% end %>
           <% end %>
@@ -41,7 +41,7 @@
             <%= food.label do %>
               <tr class="js-checkbox-<%= food.object.role %>">
                 <td><%= food.object.name %></td>
-                <td><%= food.check_box class: 'js-abstract-chk' %></td>
+                <td><%= food.check_box class: 'js-chk' %></td>
               </tr>
             <% end %>
           <% end %>

--- a/app/views/meals/edit.html.erb
+++ b/app/views/meals/edit.html.erb
@@ -11,7 +11,7 @@
         </tr>
       </thead>
       <tbody>
-        <%= f.collection_check_boxes :food_ids, @foods, :id, :name do |food| %>
+        <%= f.collection_check_boxes :food_ids, @concrete_foods, :id, :name do |food| %>
           <%= food.label do %>
             <tr class="js-checkbox-<%= food.object.role %>">
               <td><%= food.object.name %></td>
@@ -34,7 +34,7 @@
         </tr>
       </thead>
       <tbody>
-        <%= f.collection_check_boxes :food_ids, @foods, :id, :name do |food| %>
+        <%= f.collection_check_boxes :food_ids, @abstract_foods, :id, :name do |food| %>
           <%= food.label do %>
             <tr class="js-checkbox-<%= food.object.role %>">
               <td><%= food.object.name %></td>

--- a/app/views/meals/edit.html.erb
+++ b/app/views/meals/edit.html.erb
@@ -2,53 +2,57 @@
   <h1 class="mt-3">食品選択</h1>
   <%= image_tag @meal.meal_image.url, class: 'img-fluid d-block mx-auto', size: '500x500' %>
   <%= @meal.analyzed_foods %>
-  <%= form_with model: @meal, local: true, class: 'mt-3' do |f| %>
-    <table class="table table-hover table-bordered">
-      <thead>
-        <tr>
-          <th><%= Food.human_attribute_name(:name) %></th>
-          <th>選択する/しない</th>
-        </tr>
-      </thead>
-      <tbody>
-        <%= f.collection_check_boxes :food_ids, @concrete_foods, :id, :name do |food| %>
-          <%= food.label do %>
-            <tr class="js-checkbox-<%= food.object.role %>">
-              <td><%= food.object.name %></td>
-              <td><%= food.check_box class: 'chk' %></td>
-            </tr>
+  <div id="js-concrete-checkbox">
+    <%= form_with model: @meal, local: true, class: 'mt-3' do |f| %>
+      <table class="table table-hover table-bordered">
+        <thead>
+          <tr>
+            <th><%= Food.human_attribute_name(:name) %></th>
+            <th>選択する/しない</th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= f.collection_check_boxes :food_ids, @concrete_foods, :id, :name do |food| %>
+            <%= food.label do %>
+              <tr class="js-checkbox-<%= food.object.role %>">
+                <td><%= food.object.name %></td>
+                <td><%= food.check_box class: 'chk' %></td>
+              </tr>
+            <% end %>
           <% end %>
-        <% end %>
-      </tbody>
-    </table>
-    <div class="row justify-content-end mt-5">
-      <%= f.submit '選択する', class: 'btn btn-primary col-sm-2' %>
-    </div>
-  <% end %>
-  <%= form_with model: @meal, local: true, class: 'mt-3' do |f| %>
-    <table class="table table-hover table-bordered">
-      <thead>
-        <tr>
-          <th><%= Food.human_attribute_name(:name) %></th>
-          <th>選択する/しない</th>
-        </tr>
-      </thead>
-      <tbody>
-        <%= f.collection_check_boxes :food_ids, @abstract_foods, :id, :name do |food| %>
-          <%= food.label do %>
-            <tr class="js-checkbox-<%= food.object.role %>">
-              <td><%= food.object.name %></td>
-              <td><%= food.check_box class: 'chk' %></td>
-            </tr>
+        </tbody>
+      </table>
+      <div class="row justify-content-end mt-5">
+        <%= f.submit '選択する', class: 'btn btn-primary col-sm-2' %>
+      </div>
+    <% end %>
+  </div>
+  <div id="js-abstract-checkbox">
+    <%= form_with model: @meal, local: true, class: 'mt-3' do |f| %>
+      <table class="table table-hover table-bordered">
+        <thead>
+          <tr>
+            <th><%= Food.human_attribute_name(:name) %></th>
+            <th>選択する/しない</th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= f.collection_check_boxes :food_ids, @abstract_foods, :id, :name do |food| %>
+            <%= food.label do %>
+              <tr class="js-checkbox-<%= food.object.role %>">
+                <td><%= food.object.name %></td>
+                <td><%= food.check_box class: 'chk' %></td>
+              </tr>
+            <% end %>
           <% end %>
-        <% end %>
-      </tbody>
-    </table>
-    <div class="row justify-content-end mt-5">
-      <%= f.submit '選択する', class: 'btn btn-primary col-sm-2' %>
-    </div>
-  <% end %>
+        </tbody>
+      </table>
+      <div class="row justify-content-end mt-5">
+        <%= f.submit '選択する', class: 'btn btn-primary col-sm-2' %>
+      </div>
+    <% end %>
+  </div>
   <div class="row justify-content-end mt-2">
-    <button class="btn btn-danger col-sm-2">このなかにない</button>
+    <button class="btn btn-danger col-sm-2" id="js-abstract-button">このなかにない</button>
   </div>
 </div>

--- a/app/views/meals/edit.html.erb
+++ b/app/views/meals/edit.html.erb
@@ -16,7 +16,7 @@
             <%= food.label do %>
               <tr class="js-checkbox-<%= food.object.role %>">
                 <td><%= food.object.name %></td>
-                <td><%= food.check_box class: 'chk' %></td>
+                <td><%= food.check_box class: 'js-concrete-chk' %></td>
               </tr>
             <% end %>
           <% end %>
@@ -41,7 +41,7 @@
             <%= food.label do %>
               <tr class="js-checkbox-<%= food.object.role %>">
                 <td><%= food.object.name %></td>
-                <td><%= food.check_box class: 'chk' %></td>
+                <td><%= food.check_box class: 'js-abstract-chk' %></td>
               </tr>
             <% end %>
           <% end %>

--- a/app/views/meals/show.html.erb
+++ b/app/views/meals/show.html.erb
@@ -3,7 +3,7 @@
   <h1 class="mt-3 display-3 text-center <%= @meal.result_color %>"><%= @meal.result %></h1>
   <div class="row mt-5">
     <div class="col-sm-6">
-      <h2 class="text-center <%= @meal.result_color %>"><%= @meal.result_meal_title %></h2>
+      <h2 class="text-center <%= @meal.result_color %>"><%= @meal.title %></h2>
       <%= image_tag @meal.meal_image.url, class: 'img-fluid'%>
       <h4 class="text-center"><%= @meal.user.name %>さんの食事</h4>
       <h4 class="text-center">食品→<% @meal.foods.each do |food| %>

--- a/db/migrate/20211202081704_add_title_to_meals.rb
+++ b/db/migrate/20211202081704_add_title_to_meals.rb
@@ -1,0 +1,5 @@
+class AddTitleToMeals < ActiveRecord::Migration[6.0]
+  def change
+    add_column :meals, :title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_26_133224) do
+ActiveRecord::Schema.define(version: 2021_12_02_081704) do
 
   create_table "foods", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2021_11_26_133224) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "analyzed_foods"
+    t.string "title"
     t.index ["user_id"], name: "index_meals_on_user_id"
   end
 


### PR DESCRIPTION
## 概要
* 具体的な食品名の選択肢の中に何も当てあまらなかったとき、抽象的な食品のチェックボックスが表示されるようにjQueryで画面上の切り替え機能を実装
* ユーザーが何も判定できないことを防ぐため

* 必要カロリー量の算出式を食事制限用に少なく出るように修正
* 食事のタイトルの算出を都度ロジックで行うのではなく、カラムを作って、データから取り出すだけに修正。SQLの発行数を少なくするため